### PR TITLE
Update FontAwesome CDN Link for Flexible Icon Usage and Icon Display Fix

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -35,7 +35,12 @@ Aquí tienes una pista de una buena estrategia:
 Este website utiliza la font `Roboto-type` de Google Fonts e íconos de Font Awesome:
 
 - [https://fonts.google.com/](https://fonts.google.com/)
-- [https://fontawesome.com/](https://fontawesome.com/) ⚠️ Importante: [impórtalo usando una CDN](https://www.bootstrapcdn.com/fontawesome/) en lugar de buscarlo por la página oficial (pregunta al profesor si necesitas ayuda)
+- [https://fontawesome.com/](https://fontawesome.com/)
+
+```text
+ <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css">
+```
+⚠️ Importante: [impórtalo usando una CDN](https://www.jsdelivr.com/package/npm/@fortawesome/fontawesome-free) en lugar de buscarlo por la página oficial (pregunta al profesor si necesitas ayuda)
 
 ## ¿Qué hacer si estás atascado?
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ Here is a quick visual hint on a good strategy:
 To make your post look like the sample, you will need to use a `Roboto-type` font from Google Fonts and icons from Font Awesome:
 
 - [https://fonts.google.com/](https://fonts.google.com/)
-- [https://fontawesome.com/](https://fontawesome.com/) ⚠️ Important: [import font-awesome from a CDN](https://www.bootstrapcdn.com/fontawesome/) instead of the main website (ask the teacher for details if you need them)
+- [https://fontawesome.com/](https://fontawesome.com/) 
+
+```text
+ <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css">
+```
+⚠️ Important: [import font-awesome from a CDN](https://www.jsdelivr.com/package/npm/@fortawesome/fontawesome-free) instead of the main website (ask the teacher for details if you need them)
 
 
 ## What to do if you are stuck?


### PR DESCRIPTION
In this Pull Request, I've made two updates to improve the usage and display of FontAwesome icons:

1. **Update CDN Link for Flexible Icon Usage:** I've updated the CDN link in the README to ensure it always fetches the latest FontAwesome CSS file ('all.min.css'). This change allows for greater flexibility in using icons, as it no longer ties us to a specific version ('6.2.1' - 'fontawesome.min.css'). Now, students can confidently use icon classes like <i class='fa-regular fa-user'></i> and <i class='far fa-user'></i> without worrying about compatibility issues with the class names.

2. **Fix Icon Display Issues:** This update also addresses issues that some students were encountering with icon display. By switching to 'all.min.css', we ensure that icons consistently render as expected, eliminating problems related to version-specific links.